### PR TITLE
feat: add basic auth to docker-compose's solr cloud

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     image: solr:8.7.0
     container_name: solr1
     ports:
-     - "8981:8983"
+      - "8981:8983"
     environment:
       - ZK_HOST=zoo1:2181,zoo2:2181,zoo3:2181
     networks:
@@ -27,7 +27,7 @@ services:
     image: solr:8.7.0
     container_name: solr2
     ports:
-     - "8982:8983"
+      - "8982:8983"
     environment:
       - ZK_HOST=zoo1:2181,zoo2:2181,zoo3:2181
     networks:
@@ -41,11 +41,31 @@ services:
     image: solr:8.7.0
     container_name: solr3
     ports:
-     - "8983:8983"
+      - "8983:8983"
     environment:
       - ZK_HOST=zoo1:2181,zoo2:2181,zoo3:2181
     networks:
       - solr
+    depends_on:
+      - zoo1
+      - zoo2
+      - zoo3
+
+  # Add a basic auth to the solr cluster, so that you can upload your own schema config
+  # default user/password is solr/SolrRocks
+  # See: https://solr.apache.org/guide/8_7/basic-authentication-plugin.html
+  solrEnableAuth:
+    image: solr:8.7.0
+    container_name: solrEnableAuth
+    ports:
+      - "8984:8983"
+    environment:
+      - ZK_HOST=zoo1:2181,zoo2:2181,zoo3:2181
+    networks:
+      - solr
+    volumes:
+      - ./security.json:/opt/solr/server/solr/security.json
+    command: bash -c "solr zk cp /opt/solr/server/solr/security.json zk:/security.json"
     depends_on:
       - zoo1
       - zoo2

--- a/docker-compose/security.json
+++ b/docker-compose/security.json
@@ -1,0 +1,23 @@
+{
+  "authentication": {
+    "blockUnknown": true,
+    "class": "solr.BasicAuthPlugin",
+    "credentials": {
+      "solr": "IV0EHq1OnNrj6gvRCwvFwTrZ1+z1oBbnQdiVC3otuq0= Ndd7LKvVBAaZIF0QAVi1ekCfAJXr1GGfLtRUXhgrF8c="
+    },
+    "realm": "My Solr users",
+    "forwardCredentials": false
+  },
+  "authorization": {
+    "class": "solr.RuleBasedAuthorizationPlugin",
+    "permissions": [
+      {
+        "name": "security-edit",
+        "role": "admin"
+      }
+    ],
+    "user-role": {
+      "solr": "admin"
+    }
+  }
+}


### PR DESCRIPTION
Solr 8's upgrade blocks schema upload when the authentication is disabled. Adding a default `security.json` will let developer notice this intentional change.

The `solrEnableAuth` container is short-lived, it just copies the `security.json` to zookeeper and dies.

I'm not sure if this docker-compose should replace the no-basic-auth-protected `docker-compose.yml`. Let me know if it's better to put this example in a different folder.

Cheers!